### PR TITLE
Fix navbar text focus color

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -194,6 +194,11 @@ a {
   .tocify-focus {
     background-color: $nav-active-bg;
     color: $nav-active-text;
+
+    a {
+      background-color: $nav-active-bg;
+      color: $nav-active-text;
+    }
   }
 
   // Subheaders are the submenus that slide open


### PR DESCRIPTION
CSS was not specific enough and the `a {...}` setting took over.
Case 2414.