### PR TITLE
Optional signatory attachments: add `required` field to signatory attachments

### DIFF
--- a/documentation/definitions/Signatory.yaml
+++ b/documentation/definitions/Signatory.yaml
@@ -156,15 +156,36 @@ properties:
     default: []
     items:
       type: object
+      description: |
+        An attachment requested from the signing party.
+        Attachments requested from viewing only parties have no effect.
       properties:
         name:
           type: string
+          description: |
+            A name for the requested attachment.
+            Will be visible to the signatory when signing the document.
         description:
           type: string
+          description: |
+            A description for the requested attachment.
+            Will be visible to the signatory when signing the document alongside
+            the attachment name.
+        required:
+          type: boolean
+          default: true
+          description: |
+            Whether the signatory must upload this attachment.
+            If `false`, the signatory may choose not to upload this attachment
+            when signing.
         file_id:
           type: string
+          description: |
+            Will be present if and when the party uploads this attachment.
         file_name:
           type: string
+          description: |
+            Will be present if and when the party uploads this attachment.
   api_delivery_url:
     description: |
       If the `delivery_method` is set to `api`, then this field will hold the

--- a/documentation/scrive_api.yaml
+++ b/documentation/scrive_api.yaml
@@ -46,6 +46,7 @@ info:
     | 2017-01-28  | Documentation of `removepages` API call                    |
     | 2017-03-11  | Add `dk_nemid` (Danish NemID) to `authentication_to_view`  |
     | 2017-05-15  | Add missing `company` standard signatory field             |
+    | 2017-06-08  | Add `required` field to signatory attachments, optional attachments are now possible |
 
     ## Environments & IP Addresses
 


### PR DESCRIPTION
# Do not merge yet!

As this is only expected to go live on 8 June.

@trin-cz if you could review and simply "approve" PR if everything looks good.

Here are rendered views for convenience:
![screen shot 2017-05-31 at 10 25 58](https://cloud.githubusercontent.com/assets/362126/26625353/c1bce46e-45eb-11e7-8d01-42e6dabd3c48.png)
![screen shot 2017-05-31 at 10 21 09](https://cloud.githubusercontent.com/assets/362126/26625354/c1bf68f6-45eb-11e7-9195-e1b212e189ab.png)