### PR TITLE
Clarified IP address section

### DIFF
--- a/documentation/scrive_api.yaml
+++ b/documentation/scrive_api.yaml
@@ -67,16 +67,16 @@ info:
 
     ## Environments & IP Addresses
 
-	This section provides details on the IP addresses used by the Scrive Service. You may want to whitelist 
-	these addresses in your firewalls for outgoing traffic but more importantly for incoming traffic from 
-	Scrive when using callbacks.
-	
+    This section provides details on the IP addresses used by the Scrive Service. You may want to whitelist 
+    these addresses in your firewalls for outgoing traffic but more importantly for incoming traffic from 
+    Scrive eSign when using callbacks.
+
     <aside class="warning">
-    Do not call the API using these IP addresses directly! SNI is used to route calls to 
-	different services on the same IP address and thus hostnames must be used to reliably reach 
-	the service you intend to integrate with.
+    Do not call the API using these IP addresses directly! Server Name Identification (SNI) is used to 
+    route calls to different services on the same IP address and thus hostnames must be used to reliably reach 
+    the service you intend to integrate with.
     </aside>
-	
+
 
     ### Production
     The main application is available through the `scrive.com` domain.

--- a/documentation/scrive_api.yaml
+++ b/documentation/scrive_api.yaml
@@ -67,6 +67,17 @@ info:
 
     ## Environments & IP Addresses
 
+	This section provides details on the IP addresses used by the Scrive Service. You may want to whitelist 
+	these addresses in your firewalls for outgoing traffic but more importantly for incoming traffic from 
+	Scrive when using callbacks.
+	
+    <aside class="warning">
+    Do not call the API using these IP addresses directly! SNI is used to route calls to 
+	different services on the same IP address and thus hostnames must be used to reliably reach 
+	the service you intend to integrate with.
+    </aside>
+	
+
     ### Production
     The main application is available through the `scrive.com` domain.
 


### PR DESCRIPTION
Made it clearer that one should not call the API on a specific IP address but use the hostnames instead. Apparently some people think it's good to rely on which server is the default vhost.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scrive/scrive-apidocs/42)
<!-- Reviewable:end -->
