### PR TITLE
CORE-1016 Add documentation for `login_token`s - (Don't merge until after release 74)

### DIFF
--- a/documentation/api/user/gettokenforpersonalcredentials.yaml
+++ b/documentation/api/user/gettokenforpersonalcredentials.yaml
@@ -1,0 +1,31 @@
+---
+post:
+
+  summary: Get temporary login_token for a user
+
+  tags:
+    - User
+
+  description: |
+    Generate a temporary `login_token` which can be used with `getpersonaltoken`
+    to get valid OAuth credentials for that user. The endpoint also returns a
+    base64-encoded PNG image of a QR code. This QR code also contains the
+    `login_token` embedded in a simple JSON structure. The only purpose of the
+    JSON is to allow the potential for versioning in future.
+
+    This feature is generally for use with Scrive mobile applications and will
+    be supported in an upcoming relase.
+
+  parameters:
+    - name: minutes
+      in: formData
+      type: integer
+      required: false
+      default: 5
+      maximum: 30
+      description: |
+        How many minutes the `login_token` should be valid for (maximum of 30).
+
+  responses:
+    200:
+      $ref: ../../scrive_api.yaml#/definitions/LoginToken

--- a/documentation/definitions/LoginToken.yaml
+++ b/documentation/definitions/LoginToken.yaml
@@ -1,0 +1,18 @@
+---
+$schema: "http://json-schema.org/draft-04/schema#"
+title: LoginToken
+type: object
+example: {
+  "login_token":"a537e5e43d5b4095",
+  "qr_code":"iVBORw0KGgoAAAANSUhEUgAAAzQAAAM0AQMAAABXvPU0AAAABlBMVEUAAAD///+l2Z/dAAAAAnRSTlP//8i138cAAAAJcEhZcwAACxIAAAsSAdLdfvwAAAL8SURBVHic7dpLbuswDAVQ70D736V34AJFLFKfpJ28B9A9HBiRLd6jIWHnuP5PHRwOh8PhcDgcDofD4XA4HA6Hw+FwOBwOh8PhcP6Cc8zV+oOWL9d15l3fy88BHA6Hw+Fw6jrp/ib9Tno5rQe3DwEcDofD4XDqO9G6ZyP4HkZ+F8DhcDgcDucxTl4ePfgc30608cLhcDgcDufZTsTt9x0bkcPhcDgczsOcXVx+J3F/wnjVmTN3ARwOh8PhcIo7Uw39v7qsARwOh8PhcEo7+4oRZK03mdutHA6Hw+FwKjpTVyzyHxsGNkaQacv6+YPD4XA4HE5JJ1pfdS5xkRnnyQdoPeXISw6Hw+FwOFWdiVjS7/5pyBjiesfxad7hcDgcDodTxckvIebXDD0uDhD7diMIh8PhcDicRzjRPyUty2MM3g4e04DC4XA4HA6npJNDhsxd625LHlWGo3A4HA6Hw6nqTA15GV1TyJl/LQe9OBwOh8PhFHc+zCFn77qD81HOvCWecjgcDofDqe9Mo8UxVo6LA1wLlscSDofD4XA41Z0sRkjL95bpIyqIYTOHw+FwOJz6zkKcY8M9gkzjxpCZH3A4HA6HwyntBJHfSdwhMYJMw0iePoZf7+YQDofD4XA4xZwl6crEMocMbfH0WorD4XA4HE5dZ3kxcTvLr3tzXN62cTgcDofDqevc40bUFJIfDaPKm3QOh8PhcDiPcV7p072rO63HfTrAz3MIh8PhcDicEs6Uvtjn5hSrM+VxOBwOh8Op6uxq15XtH8/I4XA4HA6ntHPMFUPGd8P0ReO+92HzxeFwOBwOp7zThid9mfuvhQh7OW3K43A4HA6HU9eJHctyqpYPMD27luJwOBwOh/Mgp/Xnw7gxvaLIbzGOcR+Hw+FwOJzHOcf49WIIycSVD/Vq43A4HA6H8whnx+6SdnPI7igcDofD4XCKO1Otc0hO31XrR7lPxuFwOBwOp7TzT4vD4XA4HA6Hw+FwOBwOh8PhcDgcDofD4XA4HM5znS/lqLjLlQGH4gAAAABJRU5ErkJggg==",
+  "expiration_time":"2019-02-25 10:50:00.507433116 UTC"
+}
+description: |
+  Returns a JSON containing `login_token`, `qr_code` and `expiration_time`.
+properties:
+  login_token:
+    type: string
+  qr_code:
+    type: string
+  expiration_time:
+    type: string

--- a/documentation/scrive_api.yaml
+++ b/documentation/scrive_api.yaml
@@ -70,6 +70,7 @@ info:
     | 2018-12-17  | Add `fi_tupas` (Finnish EID) to `authentication_method_to_view`/`authentication_method_to_view_archived` |
     | 2019-01-03  | Add `usagestats` endpoints
     | 2019-02-18  | Add monitoring endpoint which was already implemented but missing from this document |
+    | 2019-02-25  | Add `gettokenforpersonalcredentials` endpoint and update `getpersonaltoken` to accept `login_token`s
 
     ## Environments & IP Addresses
 
@@ -369,9 +370,18 @@ info:
     ```
 
     > Replacing `{server_address}`, `{user_email}` and `{user_password}` to
-    > match your needs.
+    > the appropriate values.
     >
-    > This will return the personal access tokens as a JSON:
+    > Or, if you are using the `login_token` method:
+
+    ```bash
+    curl -X POST 'https://{server_address}/api/v2/getpersonaltoken' \
+      --data-urlencode 'login_token={login_token}'
+    ```
+
+    > Replacing `{server_address}`, `{login_token}` to the appropriate values.
+    >
+    > These two methods will both return the personal access tokens as a JSON:
 
     ```json
     {
@@ -410,6 +420,12 @@ info:
     used instead of any other OAuth privileges, they are intended for special
     cases where OAuth is not a viable option, or for getting started quickly in
     a sandbox environment.
+
+    There are two ways to use this endpoint. One is to provide the username and
+    password of the user you are creating the personal access credentials for.
+    The other is to provide a `login_token`. These are temporary tokens created
+    by the `gettokenforpersonalcredentials` endpoint. These are demonstrated in
+    the sidebar.
 
     <aside class="warning">
     Storing personal access tokens outside of the Scrive eSign system is
@@ -932,6 +948,9 @@ paths:
   /loginandgetsession:
     $ref: ./api/user/loginandgetsession.yaml
 
+  /gettokenforpersonalcredentials/{user_id}:
+    $ref: ./api/user/gettokenforpersonalcredentials.yaml
+
   /2fa/setup:
     $ref: ./api/user/2fa-setup.yaml
 
@@ -1001,6 +1020,8 @@ definitions:
     $ref: ./definitions/OAuthAuthorization.yaml
   UserStats:
     $ref: ./definitions/UserStats.yaml
+  LoginToken:
+    $ref: ./definitions/LoginToken.yaml
 
 parameters:
   $ref: ./extras/parameters.yaml


### PR DESCRIPTION
**Don't merge until after release 74**

Questions:

- Many endpoints have a note explaining what permissions are required (example below). What is the correct way to state that a user needs `Update` privileges on another user to create a `login_token` for them?

> _OAuth Privileges required: `DOC_CREATE`_

- What is the ideomatic way to have a hyperlink to another endpoint in the docs. It would be helpful for `getpersonaltoken` and `gettokenforpersonalcredentials` to explicitly link to each other in their definitions. I can't find a good example of that so asking seems quicker than digging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scrive/scrive-apidocs/48)
<!-- Reviewable:end -->
