### PR TITLE
reviewed nullable properties

### DIFF
--- a/documentation/definitions/Document.yaml
+++ b/documentation/definitions/Document.yaml
@@ -39,7 +39,9 @@ properties:
       Can be `null` while a document is in preparation, but needs a file before
       the signing process can start.
   sealed_file:
-    $ref: ./File.yaml
+    oneOf:
+      - type: 'null'
+      - $ref: ./File.yaml
     description: |
       **The cryptographically sealed file.**
 
@@ -82,11 +84,11 @@ properties:
   timeout_time:
     description: |
       Time after which the document will timeout if it has not been signed.
-    type: string
+    type: ['string', 'null']
     format: date-time
     readOnly: true
   auto_remind_time:
-    type: string
+    type: ['string', 'null']
     format: date-time
     readOnly: true
   status:
@@ -95,7 +97,7 @@ properties:
     type: integer
     default: 90
   days_to_remind:
-    type: integer
+    type: ['integer', 'null']
   display_options:
     type: object
     properties:
@@ -152,7 +154,7 @@ properties:
       The URL to perform an API callback request.
 
       Please see [Callbacks](#callbacks) for details.
-    type: string
+    type: ['string', 'null']
     format: uri
   object_version:
     description: |

--- a/documentation/definitions/Signatory.yaml
+++ b/documentation/definitions/Signatory.yaml
@@ -17,7 +17,7 @@ properties:
     description: |
       If this party has an account on the Scrive eSign system, it will be set
       here.
-    type: integer
+    type: ['string', 'null']
     format: int64
     readOnly: true
   is_author:
@@ -77,23 +77,23 @@ properties:
     type: integer
     default: 1
   sign_time:
-    type: string
+    type: ['string', 'null']
     format: date-time
     readOnly: true
   seen_time:
-    type: string
+    type: ['string', 'null']
     format: date-time
     readOnly: true
   read_invitation_time:
-    type: string
+    type: ['string', 'null']
     format: date-time
     readOnly: true
   rejected_time:
-    type: string
+    type: ['string', 'null']
     format: date-time
     readOnly: true
   rejection_reason:
-    type: string
+    type: ['string', 'null']
     readOnly: true
     description: |
       Will only have a value if the signatory rejected the document, and will
@@ -103,19 +103,19 @@ properties:
   sign_success_redirect_url:
     description: |
       The URL to redirect this party after they have signed the document.
-    type: string
+    type: ['string', 'null']
     format: uri
   reject_redirect_url:
     description: |
       The URL to redirect this party if they reject the document.
-    type: string
+    type: ['string', 'null']
     format: uri
   email_delivery_status:
     $ref: ./SignatoryDeliveryStatus.yaml
   mobile_delivery_status:
     $ref: ./SignatoryDeliveryStatus.yaml
   csv:
-    type: array
+    type: ['array', 'null']
     items:
       type: array
       items:
@@ -268,10 +268,12 @@ properties:
 
       This will only be available after the signing process has been started,
       and will only be visible when accessing the document as the author.
-    type: string
+    type: ['string', 'null']
     format: uri
   consent_module:
-    $ref: ./SignatoryConsentModule.yaml
+    oneOf:
+      - type: 'null'
+      - $ref: ./SignatoryConsentModule.yaml
 example:
   {
     "id": "189256",

--- a/documentation/definitions/SignatoryConsentModule.yaml
+++ b/documentation/definitions/SignatoryConsentModule.yaml
@@ -28,7 +28,7 @@ properties:
           desription: |
             Text for the negative answer.
         response:
-          type: bool
+          type: boolean
           description: |
             Will be present when the party has answered the question. `true`
             when the signatory selected the positive response and `false`

--- a/documentation/definitions/SignatoryFieldCustomText.yaml
+++ b/documentation/definitions/SignatoryFieldCustomText.yaml
@@ -48,7 +48,9 @@ properties:
       template in the document UI design view, and use those values.
     $ref: ./SignatoryFieldStandardPlacements.yaml
   custom_validation:
-    $ref: ./SignatoryFieldCustomValidation.yaml
+    oneOf:
+      - type: 'null'
+      - $ref: ./SignatoryFieldCustomValidation.yaml
 required:
   - type
   - name

--- a/documentation/definitions/SignatoryFieldCustomValidation.yaml
+++ b/documentation/definitions/SignatoryFieldCustomValidation.yaml
@@ -2,7 +2,6 @@
 $schema: "http://json-schema.org/draft-04/schema#"
 title: SignatoryFieldCustomValidation
 type: object
-default: null
 description: |
   Optional. Describes how to validate the input to this field using a
   custom regular expression.


### PR DESCRIPTION
Hi @wwwater Hi @trin-cz 

When comparing our specified data models (in YAML files) to our examples, I realized that:

* a handful of properties can have a `null`-value
* `user_id` in `Signatory` is actually represented as `string` (not as `integer`)
* `bool` should be `boolean` (see `SignatoryConsentModule`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scrive/scrive-apidocs/55)
<!-- Reviewable:end -->
