### PR TITLE
Add 'curl' Examples to Commonly Used Endpoints

### DIFF
--- a/documentation/api/documents/document_id/start.yaml
+++ b/documentation/api/documents/document_id/start.yaml
@@ -7,6 +7,16 @@ post:
     - Prepare
 
   description: |
+    > ### Example
+
+    ```bash
+    curl -X POST 'https://{server_address}/api/v2/documents/${document_id}/start' \
+      -H 'Authorization: oauth_signature_method="PLAINTEXT",oauth_consumer_key="${apitoken}",oauth_token="${accesstoken}",oauth_signature="${apisecret}&${accesssecret}"' \
+      --data-urlencode 'document_id=${document_id}'
+    ```
+
+    > The above example uses [personal access credentials](#personal-access-credentials) (see `-H` option), but can be easily updated to use [OAuth](#oauth).
+
     Start the signing process for a document in preparation.
 
     *OAuth Privileges required: `DOC_SEND`*

--- a/documentation/api/documents/document_id/update.yaml
+++ b/documentation/api/documents/document_id/update.yaml
@@ -6,6 +6,17 @@ post:
     - Prepare
 
   description: |
+    > ### Example
+
+    ```bash
+    curl -X POST 'https://{server_address}/api/v2/documents/${document_id}/update' \
+      -H 'Authorization: oauth_signature_method="PLAINTEXT",oauth_consumer_key="${apitoken}",oauth_token="${accesstoken}",oauth_signature="${apisecret}&${accesssecret}"' \
+      --data-urlencode 'document={ "id":"${document_id}", "parties": [{}] }' \
+      --data-urlencode 'document_id=${document_id}'
+    ```
+
+    > The above example uses [personal access credentials](#personal-access-credentials) (see `-H` option), but can be easily updated to use [OAuth](#oauth).
+
     Update the metadata for a document in preparation.
 
     *OAuth Privileges required: `DOC_CREATE`*

--- a/documentation/api/documents/new.yaml
+++ b/documentation/api/documents/new.yaml
@@ -6,6 +6,15 @@ post:
     - Prepare
 
   description: |
+    > ### Example
+
+    ```bash
+    curl -X POST 'https://{server_address}/api/v2/documents/new' \
+      -H 'Authorization: oauth_signature_method="PLAINTEXT",oauth_consumer_key="${apitoken}",oauth_token="${accesstoken}",oauth_signature="${apisecret}&${accesssecret}"'
+    ```
+
+    > The above example uses [personal access credentials](#personal-access-credentials) (see `-H` option), but can be easily updated to use [OAuth](#oauth).
+
     Create a new document with the given PDF (if any) as the main file.
     The new document will have state `Preparation`, and will not be a template.
 

--- a/documentation/api/documents/newfromtemplate.yaml
+++ b/documentation/api/documents/newfromtemplate.yaml
@@ -6,6 +6,15 @@ post:
     - Prepare
 
   description: |
+    > ### Example
+
+    ```bash
+    curl -X POST 'https://{server_address}/api/v2/documents/newfromtemplate/${document_id}' \
+      -H 'Authorization: oauth_signature_method="PLAINTEXT",oauth_consumer_key="${apitoken}",oauth_token="${accesstoken}",oauth_signature="${apisecret}&${accesssecret}"'
+    ```
+
+    > The above example uses [personal access credentials](#personal-access-credentials) (see `-H` option), but can be easily updated to use [OAuth](#oauth).
+
     Create a new document from a template, given the document ID for a document that is a template.
 
     The new document will have state `Preparation` and will not be a template, and the signing process can thus be carried out.


### PR DESCRIPTION
When getting started with the scrive API, one _can_ overlook the whole `formData`-thing. It is stated in the documentation, but it could be made slightly more obvious / more accessible. Adding `curl` examples to a few common endpoints is my way to accomplish this.

My assumption is that almost every developer, who uses the scrive API, will make calls to the endpoints `documents/new`, `documents/newfromtemplate/${document_id}`, `documents/${document_id}/update` and `document/${document_id}/start`. Once one has grasped the whole `formData`-thing, this knowledge is easily transferred to other endpoints.

Is it enough to add `curl` examples to these four endpoints? Should we add examples to all endpoints?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scrive/scrive-apidocs/61)
<!-- Reviewable:end -->
