### PR TITLE
Remove "object_version" from "bulk" delete|trash endpoints

### DIFF
--- a/documentation/api/documents/document_id/delete-bulk.yaml
+++ b/documentation/api/documents/document_id/delete-bulk.yaml
@@ -27,7 +27,6 @@ post:
         example: ["3","4"]
         items:
           type: string
-    - $ref: ../../../extras/parameters.yaml#/ObjectVersion
 
   responses:
     200:

--- a/documentation/api/documents/document_id/trash-bulk.yaml
+++ b/documentation/api/documents/document_id/trash-bulk.yaml
@@ -27,7 +27,6 @@ post:
         example: ["3","4"]
         items:
           type: string
-    - $ref: ../../../extras/parameters.yaml#/ObjectVersion
 
   responses:
     200:


### PR DESCRIPTION
`/api/v2/documents/delete` accepts an array of `document_ids`. The documentation also suggests that it is possible to specify an `object_version` (i.e. a single object_version, not an array). This makes perfect sense for `/api/v2/documents/763/delete`, but not for "bulk" deleting documents.

Same applies to the endpoint: `/api/v2/documents/trash`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scrive/scrive-apidocs/63)
<!-- Reviewable:end -->
