### PR TITLE
[CORE-1818] Add documentation for User Group API tags

### DIFF
--- a/documentation/api/usergroup/createusergroup.yaml
+++ b/documentation/api/usergroup/createusergroup.yaml
@@ -17,7 +17,7 @@ post:
       "name": "New UG that's the child of user group 1"
       "tags": [
         {
-          "join": "resistance"
+          "side": "dark"
         }
       ]
     }

--- a/documentation/api/usergroup/createusergroup.yaml
+++ b/documentation/api/usergroup/createusergroup.yaml
@@ -15,6 +15,11 @@ post:
     {
       "parent_id": "1",
       "name": "New UG that's the child of user group 1"
+      "tags": [
+        {
+          "join": "resistance"
+        }
+      ]
     }
     ```
 
@@ -31,6 +36,8 @@ post:
     to create root User Groups. In order to create a new child, you must have
     the requisite permissions upon the parent.
 
+    You can also set `tags`, which are arbitrary key/value pairs.
+
     A full User Group JSON response is returned which displays the state _after_
     the create operation has been performed. Performing `/update` and then
     using the `GET` endpoint should produce the same output both times.
@@ -41,9 +48,9 @@ post:
       type: string
       format: application/json
       description: |
-        JSON object containing the `name` and `parent_id` of the User Group to
-        be created.
-      example: { "name": "new user group", "parent_id": 1 }
+        JSON object containing the `name`, `parent_id`, and `tags` of the User
+        Group to be created.
+      example: { "name": "new user group", "parent_id": 1, "tags": [] }
       required: true
     - name: include-inheritable
       in: query

--- a/documentation/api/usergroup/getusergroup.yaml
+++ b/documentation/api/usergroup/getusergroup.yaml
@@ -40,8 +40,8 @@ get:
         "address": {
           "company_number": "5568166804",
           "company_name": "Scrive",
-          "address": "Barnhusgatan 20",
-          "zip": "111 23",
+          "address": "Grev Turegatan 11A",
+          "zip": "114 46",
           "city": "Stockholm",
           "country": "Sweden"
         }
@@ -103,8 +103,8 @@ get:
         "address": {
           "company_number": "5568166804",
           "company_name": "Scrive",
-          "address": "Barnhusgatan 20",
-          "zip": "111 23",
+          "address": "Grev Turegatan 11A",
+          "zip": "114 46",
           "city": "Stockholm",
           "country": "Sweden"
         },
@@ -113,8 +113,8 @@ get:
           "address": {
             "company_number": "5568166804",
             "company_name": "Scrive",
-            "address": "Barnhusgatan 20",
-            "zip": "111 23",
+            "address": "Grev Turegatan 11A",
+            "zip": "114 46",
             "city": "Stockholm",
             "country": "Sweden"
           }

--- a/documentation/api/usergroup/getusergroup.yaml
+++ b/documentation/api/usergroup/getusergroup.yaml
@@ -39,6 +39,7 @@ get:
         "inherited_from": "1",
         "address": {
           "company_number": "5568166804",
+          "company_name": "Scrive",
           "address": "Barnhusgatan 20",
           "zip": "111 23",
           "city": "Stockholm",
@@ -101,6 +102,7 @@ get:
         "inherited_from": "1",
         "address": {
           "company_number": "5568166804",
+          "company_name": "Scrive",
           "address": "Barnhusgatan 20",
           "zip": "111 23",
           "city": "Stockholm",
@@ -110,6 +112,7 @@ get:
           "inherited_from": "1",
           "address": {
             "company_number": "5568166804",
+            "company_name": "Scrive",
             "address": "Barnhusgatan 20",
             "zip": "111 23",
             "city": "Stockholm",

--- a/documentation/api/usergroup/getusergroup.yaml
+++ b/documentation/api/usergroup/getusergroup.yaml
@@ -44,7 +44,15 @@ get:
           "city": "Stockholm",
           "country": "Sweden"
         }
-      }
+      },
+      "tags": [
+        {
+          "founded": "1846"
+        },
+        {
+          "status": "busy"
+        }
+      ]
     }
     ```
 
@@ -108,7 +116,15 @@ get:
             "country": "Sweden"
           }
         }
-      }
+      },
+      "tags": [
+        {
+          "founded": "1846"
+        },
+        {
+          "status": "busy"
+        }
+      ]
     }
     ```
 

--- a/documentation/api/usergroup/getusergroupcontactdetails.yaml
+++ b/documentation/api/usergroup/getusergroupcontactdetails.yaml
@@ -14,8 +14,8 @@ get:
       "address": {
         "company_number": "5568166804",
         "company_name": "Scrive",
-        "address": "Barnhusgatan 20",
-        "zip": "111 23",
+        "address": "Grev Turegatan 11A",
+        "zip": "114 46",
         "city": "Stockholm",
         "country": "Sweden"
       }
@@ -60,8 +60,8 @@ get:
         "address": {
           "company_number": "5568166804",
           "company_name": "Scrive",
-          "address": "Barnhusgatan 20",
-          "zip": "111 23",
+          "address": "Grev Turegatan 11A",
+          "zip": "114 46",
           "city": "Stockholm",
           "country": "Sweden"
         }
@@ -79,8 +79,8 @@ get:
       "address": {
         "company_number": "5568166804",
         "company_name": "Scrive",
-        "address": "Barnhusgatan 20",
-        "zip": "111 23",
+        "address": "Grev Turegatan 11A",
+        "zip": "114 46",
         "city": "Stockholm",
         "country": "Sweden"
       },
@@ -89,8 +89,8 @@ get:
         "address": {
           "company_number": "5568166804",
           "company_name": "Scrive",
-          "address": "Barnhusgatan 20",
-          "zip": "111 23",
+          "address": "Grev Turegatan 11A",
+          "zip": "114 46",
           "city": "Stockholm",
           "country": "Sweden"
         }

--- a/documentation/api/usergroup/getusergroupcontactdetails.yaml
+++ b/documentation/api/usergroup/getusergroupcontactdetails.yaml
@@ -13,6 +13,7 @@ get:
       "inherited_from": "1",
       "address": {
         "company_number": "5568166804",
+        "company_name": "Scrive",
         "address": "Barnhusgatan 20",
         "zip": "111 23",
         "city": "Stockholm",
@@ -30,6 +31,7 @@ get:
       "inherited_from": null,
       "address": {
         "company_number": "0987654321",
+        "company_name": "Scrive",
         "address": "Other Street",
         "zip": "00-321",
         "city": "Warsaw",
@@ -47,6 +49,7 @@ get:
       "inherited_from": null,
       "address": {
         "company_number": "0987654321",
+        "company_name": "Scrive",
         "address": "123 Other Street",
         "zip": "00-321",
         "city": "Warsaw",
@@ -56,6 +59,7 @@ get:
         "inherited_from": "1",
         "address": {
           "company_number": "5568166804",
+          "company_name": "Scrive",
           "address": "Barnhusgatan 20",
           "zip": "111 23",
           "city": "Stockholm",
@@ -74,6 +78,7 @@ get:
       "inherited_from": "1",
       "address": {
         "company_number": "5568166804",
+        "company_name": "Scrive",
         "address": "Barnhusgatan 20",
         "zip": "111 23",
         "city": "Stockholm",
@@ -83,6 +88,7 @@ get:
         "inherited_from": "1",
         "address": {
           "company_number": "5568166804",
+          "company_name": "Scrive",
           "address": "Barnhusgatan 20",
           "zip": "111 23",
           "city": "Stockholm",

--- a/documentation/api/usergroup/updateusergroup.yaml
+++ b/documentation/api/usergroup/updateusergroup.yaml
@@ -51,6 +51,7 @@ post:
     + If the value of a tag is a string, the key/value pair is stored,
       overwriting the previous value associated with that key.
     + If the value of a tag is `null`, the key/value pair is removed.
+    + Other value types lead to 400 Bad Request response.
 
     The endpoint supports partial updates. This means that only the fields you
     supply in your requests will have their values altered.

--- a/documentation/api/usergroup/updateusergroup.yaml
+++ b/documentation/api/usergroup/updateusergroup.yaml
@@ -15,6 +15,14 @@ post:
     {
       "parent_id": "1",
       "name": "UG that's now the child of user group 1"
+      "tags": [
+        {
+          "station": "ISS"
+        },
+        {
+          "lifeform": null
+        }
+      ]
     }
     ```
 
@@ -36,6 +44,13 @@ post:
     + A child User Group may be moved to be a child of another User Group as long
     as you have permissions to update the group being moved, the new parent and
     the old parent.
+
+    Tags are updated as follows:
+
+    + Only the provided tags are affected on the server.
+    + If the value of a tag is a string, the key/value pair is stored,
+      overwriting the previous value associated with that key.
+    + If the value of a tag is `null`, the key/value pair is removed.
 
     The endpoint supports partial updates. This means that only the fields you
     supply in your requests will have their values altered.
@@ -60,7 +75,7 @@ post:
       description: |
         JSON object containing the new `name` and/or `parent_id` for the User
         Group.
-      example: { "name": "new user group", "parent_id": 1 }
+      example: { "name": "new user group", "parent_id": 1, "tags": [] }
       required: true
     - name: include-inheritable
       in: formData

--- a/documentation/api/usergroup/updateusergroup.yaml
+++ b/documentation/api/usergroup/updateusergroup.yaml
@@ -73,9 +73,9 @@ post:
       type: string
       format: application/json
       description: |
-        JSON object containing the new `name` and/or `parent_id` for the User
+        JSON object containing the new `name`, `parent_id` or `tags` for the User
         Group.
-      example: { "name": "new user group", "parent_id": 1, "tags": [] }
+      example: { "name": "new user group", "parent_id": 1, "tags": [ { "foo": "bar" } ] }
       required: true
     - name: include-inheritable
       in: formData

--- a/documentation/api/usergroup/updateusergroupcontactdetails.yaml
+++ b/documentation/api/usergroup/updateusergroupcontactdetails.yaml
@@ -15,19 +15,18 @@ post:
 
     ```json
     {
-      "data_retention_policy": {
-        "idle_doc_timeout_preparation": null,
-        "idle_doc_timeout_closed": null,
-        "idle_doc_timeout_canceled": null,
-        "idle_doc_timeout_timedout": null,
-        "idle_doc_timeout_rejected": null,
-        "idle_doc_timeout_error": null,
-        "immediate_trash": false
+      "address": {
+        "company_number": "0987654321",
+        "company_name": "Scrive",
+        "address": "123 Other Street",
+        "zip": "00-321",
+        "city": "Warsaw",
+        "country": "Poland"
       }
     }
     ```
 
-    > For examples of the JSON output, see 
+    > For examples of the JSON output, see
     > [View User Group Contact Details](#view-user-group-contact-details).
 
     This endpoint allows you to update the User Group's `contact_details` object.

--- a/documentation/definitions/UserGroup.yaml
+++ b/documentation/definitions/UserGroup.yaml
@@ -33,8 +33,8 @@ example: {
     "address": {
       "company_number": "5568166804",
       "company_name": "Scrive",
-      "address": "Barnhusgatan 20",
-      "zip": "111 23",
+      "address": "Grev Turegatan 11A",
+      "zip": "114 46",
       "city": "Stockholm",
       "country": "Sweden"
     }

--- a/documentation/definitions/UserGroup.yaml
+++ b/documentation/definitions/UserGroup.yaml
@@ -69,7 +69,4 @@ properties:
   contact_details:
     $ref: ./UserGroupContactDetails.yaml
   tags:
-    type: array
-    default: []
-    items:
-      type: object
+    $ref: ./UserGroupTags.yaml

--- a/documentation/definitions/UserGroup.yaml
+++ b/documentation/definitions/UserGroup.yaml
@@ -32,6 +32,7 @@ example: {
     "inherited_from": null,
     "address": {
       "company_number": "5568166804",
+      "company_name": "Scrive",
       "address": "Barnhusgatan 20",
       "zip": "111 23",
       "city": "Stockholm",

--- a/documentation/definitions/UserGroup.yaml
+++ b/documentation/definitions/UserGroup.yaml
@@ -37,7 +37,12 @@ example: {
       "city": "Stockholm",
       "country": "Sweden"
     }
-  }
+  },
+  "tags": [
+    {
+      "alignment": "chaotic good"
+    }
+  ]
 }
 description: |
   JSON representation of a User Group.
@@ -62,3 +67,8 @@ properties:
     $ref: ./UserGroupSettings.yaml
   contact_details:
     $ref: ./UserGroupContactDetails.yaml
+  tags:
+    type: array
+    default: []
+    items:
+      type: object

--- a/documentation/definitions/UserGroupContactDetails.yaml
+++ b/documentation/definitions/UserGroupContactDetails.yaml
@@ -7,8 +7,8 @@ example: {
   "address": {
     "company_number": "5568166804",
     "company_name": "Scrive",
-    "address": "Barnhusgatan 20",
-    "zip": "111 23",
+    "address": "Grev Turegatan 11A",
+    "zip": "114 46",
     "city": "Stockholm",
     "country": "Sweden"
   }

--- a/documentation/definitions/UserGroupContactDetails.yaml
+++ b/documentation/definitions/UserGroupContactDetails.yaml
@@ -6,6 +6,7 @@ example: {
   "inherited_from": null,
   "address": {
     "company_number": "5568166804",
+    "company_name": "Scrive",
     "address": "Barnhusgatan 20",
     "zip": "111 23",
     "city": "Stockholm",
@@ -21,6 +22,8 @@ properties:
     type: object
     properties:
      company_number:
+        type: string
+     company_name:
         type: string
      address:
         type: string

--- a/documentation/definitions/UserGroupContactDetailsWithInheritable.yaml
+++ b/documentation/definitions/UserGroupContactDetailsWithInheritable.yaml
@@ -6,6 +6,7 @@ example: {
   "inherited_from": "1",
   "address": {
     "company_number": "5568166804",
+    "company_name": "Scrive",
     "address": "Barnhusgatan 20",
     "zip": "111 23",
     "city": "Stockholm",
@@ -15,6 +16,7 @@ example: {
     "inherited_from": "1",
     "address": {
       "company_number": "5568166804",
+      "company_name": "Scrive",
       "address": "Barnhusgatan 20",
       "zip": "111 23",
       "city": "Stockholm",
@@ -33,6 +35,8 @@ properties:
     properties:
      company_number:
         type: string
+     company_name:
+        type: string
      address:
         type: string
      zip:
@@ -50,6 +54,8 @@ properties:
         type: object
         properties:
           company_number:
+              type: string
+          company_name:
               type: string
           address:
               type: string

--- a/documentation/definitions/UserGroupContactDetailsWithInheritable.yaml
+++ b/documentation/definitions/UserGroupContactDetailsWithInheritable.yaml
@@ -7,8 +7,8 @@ example: {
   "address": {
     "company_number": "5568166804",
     "company_name": "Scrive",
-    "address": "Barnhusgatan 20",
-    "zip": "111 23",
+    "address": "Grev Turegatan 11A",
+    "zip": "114 46",
     "city": "Stockholm",
     "country": "Sweden"
   },
@@ -17,8 +17,8 @@ example: {
     "address": {
       "company_number": "5568166804",
       "company_name": "Scrive",
-      "address": "Barnhusgatan 20",
-      "zip": "111 23",
+      "address": "Grev Turegatan 11A",
+      "zip": "114 46",
       "city": "Stockholm",
       "country": "Sweden"
     }

--- a/documentation/definitions/UserGroupTags.yaml
+++ b/documentation/definitions/UserGroupTags.yaml
@@ -16,6 +16,7 @@ description: |
   Each tag must have `{key: value}` format.
   In the responses value is always a string.
   In the requests you can also provide `null` to delete a tag.
+  Other value types lead to 400 Bad Request response.
 default: []
 items:
   type: object

--- a/documentation/definitions/UserGroupTags.yaml
+++ b/documentation/definitions/UserGroupTags.yaml
@@ -1,0 +1,25 @@
+---
+$schema: "http://json-schema.org/draft-04/schema#"
+title: UserGroupTags
+type: array
+example: [
+  {
+    "founded": "1846"
+  },
+  {
+    "status": "busy"
+  }
+]
+description: |
+  **User defined set of keys and values.**
+
+  Each tag must have `{key: value}` format.
+  In the responses value is always a string.
+  In the requests you can also provide `null` to delete a tag.
+default: []
+items:
+  type: object
+  minProperties: 1
+  maxProperties: 1
+  additionalProperties:
+    type: string

--- a/documentation/definitions/UserGroupWithInheritable.yaml
+++ b/documentation/definitions/UserGroupWithInheritable.yaml
@@ -59,7 +59,12 @@ example: {
         "country": "Sweden"
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "home-planet": "Earth"
+    }
+  ]
 }
 description: |
   JSON representation of a User Group (with Inheritable Previews).
@@ -84,3 +89,8 @@ properties:
     $ref: ./UserGroupSettingsWithInheritable.yaml
   contact_details:
     $ref: ./UserGroupContactDetailsWithInheritable.yaml
+  tags:
+    type: array
+    default: []
+    items:
+      type: object

--- a/documentation/definitions/UserGroupWithInheritable.yaml
+++ b/documentation/definitions/UserGroupWithInheritable.yaml
@@ -45,8 +45,8 @@ example: {
     "address": {
       "company_number": "5568166804",
       "company_name": "Scrive",
-      "address": "Barnhusgatan 20",
-      "zip": "111 23",
+      "address": "Grev Turegatan 11A",
+      "zip": "114 46",
       "city": "Stockholm",
       "country": "Sweden"
     },
@@ -55,8 +55,8 @@ example: {
       "address": {
         "company_number": "5568166804",
         "company_name": "Scrive",
-        "address": "Barnhusgatan 20",
-        "zip": "111 23",
+        "address": "Grev Turegatan 11A",
+        "zip": "114 46",
         "city": "Stockholm",
         "country": "Sweden"
       }

--- a/documentation/definitions/UserGroupWithInheritable.yaml
+++ b/documentation/definitions/UserGroupWithInheritable.yaml
@@ -92,7 +92,4 @@ properties:
   contact_details:
     $ref: ./UserGroupContactDetailsWithInheritable.yaml
   tags:
-    type: array
-    default: []
-    items:
-      type: object
+    $ref: ./UserGroupTags.yaml

--- a/documentation/definitions/UserGroupWithInheritable.yaml
+++ b/documentation/definitions/UserGroupWithInheritable.yaml
@@ -44,6 +44,7 @@ example: {
     "inherited_from": "1",
     "address": {
       "company_number": "5568166804",
+      "company_name": "Scrive",
       "address": "Barnhusgatan 20",
       "zip": "111 23",
       "city": "Stockholm",
@@ -53,6 +54,7 @@ example: {
       "inherited_from": "1",
       "address": {
         "company_number": "5568166804",
+        "company_name": "Scrive",
         "address": "Barnhusgatan 20",
         "zip": "111 23",
         "city": "Stockholm",

--- a/documentation/scrive_api.yaml
+++ b/documentation/scrive_api.yaml
@@ -1116,6 +1116,8 @@ definitions:
     $ref: ./definitions/UserGroupContactDetails.yaml
   UserGroupContactDetailsWithInheritable:
     $ref: ./definitions/UserGroupContactDetailsWithInheritable.yaml
+  UserGroupTags:
+    $ref: ./definitions/UserGroupTags.yaml
   AccessRole:
     $ref: ./definitions/AccessRole.yaml
   Folder:


### PR DESCRIPTION
This PR documents User Group Tags and the API that's used to view and manage them.

One of the commits also fixes an incorrect example JSON for User Group Contact Details; it also adds missing `company_name` field to contact detail definition and examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scrive/scrive-apidocs/78)
<!-- Reviewable:end -->
