### PR TITLE
CORE-2039: Update View Folder endpoint documentation

### DIFF
--- a/documentation/api/folders/getfolder.yaml
+++ b/documentation/api/folders/getfolder.yaml
@@ -26,8 +26,9 @@ get:
     contents of the folder are not displayed, just the metadata about the
     folder.
 
-    This metadata currently consists of the folder's ID, it's parent ID (if any)
-    and the name/id of its immediate children (if any).
+    This metadata currently consists of the folder's ID, its parent ID (if any)
+    and the name/id of its children (if any). Only the immediate children are
+    included by default (see the `recursive` parameter).
 
   parameters:
     - name: folder_id
@@ -35,6 +36,14 @@ get:
       type: string
       description: The ID of the Folder you wish to view
       required: true
+    - name: recursive
+      in: query
+      type: boolean
+      description: |
+        Set ?recursive=true to include all descendant folders in the metadata
+        instead of just the immediate children.
+      required: false
+      default: false
 
   responses:
     200:

--- a/documentation/api/folders/getfolder.yaml
+++ b/documentation/api/folders/getfolder.yaml
@@ -11,12 +11,16 @@ get:
     ```json
     {
       "id": "1",
-      "parent_id": null,
       "name": "Root folder",
+      "home_for_user": null,
+      "home_for_user_group": "10",
+      "parent_id": null,
       "children": [
         {
           "id": "2",
-          "name": "Subfolder of 1"
+          "name": "Subfolder of 1",
+          "home_for_user": "33",
+          "home_for_user_group": null
         }
       ]
     }
@@ -26,8 +30,9 @@ get:
     contents of the folder are not displayed, just the metadata about the
     folder.
 
-    This metadata currently consists of the folder's ID, its parent ID (if any)
-    and the name/id of its children (if any). Only the immediate children are
+    This metadata currently consists of the folder's ID, name, its parent ID (if any),
+    IDs of the user and the user group for whom the folder is a home folder
+    and information about its children. Only the immediate children are
     included by default (see the `recursive` parameter).
 
   parameters:

--- a/documentation/definitions/Folder.yaml
+++ b/documentation/definitions/Folder.yaml
@@ -37,15 +37,15 @@ properties:
   name:
     type: string
   home_for_user:
-    type: ['string', 'null']
+    type: string
     description: |
       If the folder is a home folder for a user this field contains the ID of that user. Otherwise it's null.
   home_for_user_group:
-    type: ['string', 'null']
+    type: string
     description: |
       If the folder is a home folder for a user group this field contains the ID of that group. Otherwise it's null.
   parent_id:
-    type: ['string', 'null']
+    type: string
     description: |
       Optional property. If present contains either the ID of the parent folder
       or null if the requested folder is root.

--- a/documentation/definitions/Folder.yaml
+++ b/documentation/definitions/Folder.yaml
@@ -7,23 +7,37 @@ example:
     "id": "1",
     "parent_id": null,
     "name": "Root folder",
-    "children": [{ "id": "2", "name": "Subfolder of 1" }],
+    "children": [
+      {
+        "id": "2",
+        "name": "Subfolder of 1",
+        "children": [
+          {
+            "id": "3",
+            "name": "Subfolder of 2"
+          }
+        ]
+      }
+    ]
   }
 description: |
   JSON representation of a Folder.
+required:
+  - id
+  - name
 properties:
   id:
     type: string
   parent_id:
-    type: string
+    type: ['string', 'null']
+    description: |
+      Optional property. If present contains either the ID of the parent folder
+      or null if the requested folder is root.
   name:
     type: string
   children:
     type: array
     items:
-      type: object
-      properties:
-        id:
-          type: string
-        name:
-          type: string
+      type: Folder
+    description: |
+      Optional property. If present contains either the immediate children or all descendant folders.

--- a/documentation/definitions/Folder.yaml
+++ b/documentation/definitions/Folder.yaml
@@ -5,16 +5,22 @@ type: object
 example:
   {
     "id": "1",
-    "parent_id": null,
     "name": "Root folder",
+    "home_for_user": null,
+    "home_for_user_group": "10",
+    "parent_id": null,
     "children": [
       {
         "id": "2",
         "name": "Subfolder of 1",
+        "home_for_user": "33",
+        "home_for_user_group": null,
         "children": [
           {
             "id": "3",
-            "name": "Subfolder of 2"
+            "name": "Subfolder of 2",
+            "home_for_user": "44",
+            "home_for_user_group": null
           }
         ]
       }
@@ -28,13 +34,21 @@ required:
 properties:
   id:
     type: string
+  name:
+    type: string
+  home_for_user:
+    type: ['string', 'null']
+    description: |
+      If the folder is a home folder for a user this field contains the ID of that user. Otherwise it's null.
+  home_for_user_group:
+    type: ['string', 'null']
+    description: |
+      If the folder is a home folder for a user group this field contains the ID of that group. Otherwise it's null.
   parent_id:
     type: ['string', 'null']
     description: |
       Optional property. If present contains either the ID of the parent folder
       or null if the requested folder is root.
-  name:
-    type: string
   children:
     type: array
     items:

--- a/documentation/scrive_api.yaml
+++ b/documentation/scrive_api.yaml
@@ -44,8 +44,8 @@ info:
 
     | Date        | Details of changes                                         |
     | ----------- | ---------------------------------------------------------- |
+    | 2020-06-15  | View Folder endpoint: added `recursive` parameter and fields: `home_for_user`, `home_for_user_group`. |
     | 2020-06-02  | Add Onfido authentication to sign methods, also add missing `fi_tupas` for setauthenticationtosign`. |
-    | 2020-05-27  | Add `recursive` parameter to the View Folder endpoint. |
     | 2020-05-08  | Added IP address to [Environments & IP Addresses](#environments-amp-ip-addresses). |
     | 2020-04-20  | Added `nl_idin` and `fi_tupas` to various `authentication_method_to_*`. |
     | 2020-04-02  | Updated endpoint list to include missing ip-addresses. |

--- a/documentation/scrive_api.yaml
+++ b/documentation/scrive_api.yaml
@@ -45,6 +45,7 @@ info:
     | Date        | Details of changes                                         |
     | ----------- | ---------------------------------------------------------- |
     | 2020-06-02  | Add Onfido authentication to sign methods, also add missing `fi_tupas` for setauthenticationtosign`. |
+    | 2020-05-27  | Add `recursive` parameter to the View Folder endpoint. |
     | 2020-05-08  | Added IP address to [Environments & IP Addresses](#environments-amp-ip-addresses). |
     | 2020-04-20  | Added `nl_idin` and `fi_tupas` to various `authentication_method_to_*`. |
     | 2020-04-02  | Updated endpoint list to include missing ip-addresses. |


### PR DESCRIPTION
Update the View Folder API documentation with additions related to the [Folders tab](https://scriveab.atlassian.net/browse/CORE-2039) feature in the new adminonly (in production now).
- Add `recursive` parameter
- Add fields: `home_for_user` and `home_for_user_group`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scrive/scrive-apidocs/89)
<!-- Reviewable:end -->
