### PR TITLE
Add missing enum values in definitions/ApiError.yaml

### DIFF
--- a/documentation/definitions/ApiError.yaml
+++ b/documentation/definitions/ApiError.yaml
@@ -8,6 +8,7 @@ properties:
     type: string
     enum:
       - server_error
+      - request_failed
       - endpoint_not_found
       - invalid_authorisation
       - insufficient_privileges
@@ -19,6 +20,8 @@ properties:
       - document_object_version_mismatch
       - document_state_error
       - signatory_state_error
+      - action_not_permitted
+      - conflict_error
   error_message:
     type: string
   http_code:


### PR DESCRIPTION
Added 3 extra error types that kontrakcja can return.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scrive/scrive-apidocs/90)
<!-- Reviewable:end -->
