### PR TITLE
FLOW-436 Access control documentation

### DIFF
--- a/documentation/api/accesscontrol/deleterole.yaml
+++ b/documentation/api/accesscontrol/deleterole.yaml
@@ -17,7 +17,7 @@ post:
     - name: role_id
       in: url
       type: integer
-      description: The ID of the Access Role you wish to view
+      description: The ID of the Access Role you wish to delete
       required: true
 
   responses:

--- a/documentation/api/accesscontrol/getrole.yaml
+++ b/documentation/api/accesscontrol/getrole.yaml
@@ -77,7 +77,7 @@ get:
     set to `true` and `id` set to `null`.
 
     Explicit roles are those which have been, as the name suggests, explicitly
-    granted. This was also almost done certainly via this API. Explicit roles
+    granted. This was also almost certainly done via this API. Explicit roles
     have `is_generated` set to `false` and a non-`null` `id`.
 
   parameters:

--- a/documentation/scrive_api.yaml
+++ b/documentation/scrive_api.yaml
@@ -1066,7 +1066,7 @@ paths:
   /accesscontrol/roles/{role_id}:
     $ref: ./api/accesscontrol/getrole.yaml
 
-  /accesscontrol/roles/{role_id}/add:
+  /accesscontrol/roles/add:
     $ref: ./api/accesscontrol/createrole.yaml
 
   /accesscontrol/roles/{role_id}/delete:


### PR DESCRIPTION
Fixing some typos I noticed when studying access control.

We also discussed removing `allowed_actions` from the docs, since it doesn't properly belong with roles, but I actually like that the docs match the API for now. The API should deprecate the field first.